### PR TITLE
イベント情報と予約情報のDTOを追加し、APIレスポンスでのデータ交換を可能にする

### DIFF
--- a/src/main/java/com/example/ticketreservation/controller/EventApiController.java
+++ b/src/main/java/com/example/ticketreservation/controller/EventApiController.java
@@ -1,0 +1,35 @@
+package com.example.ticketreservation.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.example.ticketreservation.dto.EventDto;
+import com.example.ticketreservation.service.EventService;
+
+/**
+ * イベント情報API用のREST コントローラー
+ * JSON形式で全てのイベント情報を提供
+ */
+@RestController
+@RequestMapping("/api/all-events")
+public class EventApiController {
+
+    @Autowired
+    private EventService eventService;
+    
+    /**
+     * 全てのイベント一覧を取得
+     * 
+     * @return イベント一覧（JSON形式）
+     */
+    @GetMapping
+    public List<EventDto> getAllEvents() {
+        return eventService.getAllEvents()
+                .stream()
+                .map(EventDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/ticketreservation/dto/EventDto.java
+++ b/src/main/java/com/example/ticketreservation/dto/EventDto.java
@@ -1,0 +1,77 @@
+package com.example.ticketreservation.dto;
+
+/**
+ * イベント情報のデータ転送オブジェクト（DTO）
+ * APIレスポンスやリクエストでのデータ交換に使用
+ */
+public record EventDto(
+    Long id,
+    String eventName,
+    String description,
+    LocalDateTime eventDate,
+    String venue,
+    String category,
+    Integer totalSeats,
+    Integer availableSeats,
+    Double price,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+    
+    /**
+     * EventエンティティからEventDtoを作成するファクトリメソッド
+     * 
+     * @param event Eventエンティティ
+     * @return EventDto
+     */
+    public static EventDto fromEntity(Event event) {
+        return new EventDto(
+            event.getId(),
+            event.getEventName(),
+            event.getDescription(),
+            event.getEventDate(),
+            event.getVenue(),
+            event.getCategory(),
+            event.getTotalSeats(),
+            event.getAvailableSeats(),
+            event.getPrice(),
+            event.getCreatedAt(),
+            event.getUpdatedAt()
+        );
+    }
+    
+    /**
+     * EventDtoからEventエンティティを作成するメソッド
+     * 新規作成時に使用（IDなし）
+     * 
+     * @return Event エンティティ
+     */
+    public Event toEntity() {
+        return new Event(
+            this.eventName,
+            this.description,
+            this.eventDate,
+            this.venue,
+            this.category,
+            this.totalSeats,
+            this.price
+        );
+    }
+    
+    /**
+     * 既存のEventエンティティに値を設定するメソッド
+     * 更新時に使用
+     * 
+     * @param event 更新対象のEventエンティティ
+     */
+    public void updateEntity(Event event) {
+        event.setEventName(this.eventName);
+        event.setDescription(this.description);
+        event.setEventDate(this.eventDate);
+        event.setVenue(this.venue);
+        event.setCategory(this.category);
+        event.setTotalSeats(this.totalSeats);
+        event.setAvailableSeats(this.availableSeats);
+        event.setPrice(this.price);
+    }
+}

--- a/src/main/java/com/example/ticketreservation/dto/ReservationDto.java
+++ b/src/main/java/com/example/ticketreservation/dto/ReservationDto.java
@@ -1,0 +1,36 @@
+package com.example.ticketreservation.dto;
+
+/**
+ * 予約情報のデータ転送オブジェクト（DTO）
+ * APIレスポンスやリクエストでのデータ交換に使用
+ */
+public record ReservationDto(
+    Long id,
+    Long eventId,
+    String eventName,
+    String email,
+    Integer quantity,
+    String confirmationCode,
+    LocalDateTime reservationTime,
+    LocalDateTime createdAt
+) {
+    
+    /**
+     * ReservationエンティティからReservationDtoを作成するファクトリメソッド
+     * 
+     * @param reservation Reservationエンティティ
+     * @return ReservationDto
+     */
+    public static ReservationDto fromEntity(Reservation reservation) {
+        return new ReservationDto(
+            reservation.getId(),
+            reservation.getEvent().getId(),
+            reservation.getEvent().getEventName(),
+            reservation.getEmail(),
+            reservation.getQuantity(),
+            reservation.getConfirmationCode(),
+            reservation.getReservationTime(),
+            reservation.getCreatedAt()
+        );
+    }
+}


### PR DESCRIPTION
このプルリクエストは、イベントデータを取得するための新しいAPIコントローラと、イベントおよび予約のためのデータ転送オブジェクト（DTO）の作成を導入しています。これらの変更は、データ変換に構造化されたアプローチを導入することにより、APIリクエストとレスポンスの処理を効率化することを目的としています。

### API機能強化：
* `EventApiController`を追加し、JSONフォーマットですべてのイベントデータを取得するためのREST APIエンドポイント（`/api/all-events`）を提供しました。このコントローラは`EventService`を活用してデータを取得し、APIレスポンス用にDTOに変換します。

### データ転送オブジェクト（DTO）：
* API連携のためのイベントデータを表現する`EventDto`を導入しました。これには`Event`エンティティと`EventDto`オブジェクト間の変換のためのファクトリメソッド、およびエンティティの作成と更新のためのメソッドが含まれています。
* API連携のための予約データを表現する`ReservationDto`を追加しました。これには`Reservation`エンティティを`ReservationDto`オブジェクトに変換するためのファクトリメソッドが含まれています。